### PR TITLE
Add reprex for GitHub Action failure

### DIFF
--- a/.github/workflows/python-package-version.yml
+++ b/.github/workflows/python-package-version.yml
@@ -60,12 +60,4 @@ jobs:
         uses: snyk/actions/docker@master
         with:
           image: "${{ env.IMAGE_NAME }}"
-          args: |
-            --debug \
-            --exclude-base-image-vulns \
-            --file="./python-package-version/Dockerfile" \
-            --format="legacy" \
-            --org="${SNYK_ORG}" \
-            --platform="linux/amd64" \
-            --policy-path="./python-package-version/.snyk" \
-            --severity-threshold="high"
+          args: --debug --exclude-base-image-vulns --file="./python-package-version/Dockerfile" --format="legacy" --org="${SNYK_ORG}" --platform="linux/amd64" --policy-path="./python-package-version/.snyk" --severity-threshold="high"

--- a/.github/workflows/python-package-version.yml
+++ b/.github/workflows/python-package-version.yml
@@ -60,13 +60,12 @@ jobs:
         uses: snyk/actions/docker@master
         with:
           image: "${{ env.IMAGE_NAME }}"
-          command: "container test"
           args: |
-            --debug
-            --exclude-base-image-vulns
-            --file="./python-package-version/Dockerfile"
-            --format="legacy"
-            --org="${SNYK_ORG}"
-            --platform="linux/amd64"
-            --policy-path="./python-package-version/.snyk"
+            --debug \
+            --exclude-base-image-vulns \
+            --file="./python-package-version/Dockerfile" \
+            --format="legacy" \
+            --org="${SNYK_ORG}" \
+            --platform="linux/amd64" \
+            --policy-path="./python-package-version/.snyk" \
             --severity-threshold="high"

--- a/.github/workflows/python-package-version.yml
+++ b/.github/workflows/python-package-version.yml
@@ -1,0 +1,71 @@
+name: Scan Python Package Version
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest-4x
+    env:
+      IMAGE_NAME: "rstudio/rstudio-workbench-snyk:latest"
+      SNYK_ORG: ${{ secrets.SNYK_ORG }}
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup Snyk
+        uses: snyk/actions/setup@master
+
+      - name: Snyk Auth
+        shell: bash
+        run: |
+          snyk auth ${{ secrets.SNYK_TOKEN }}
+
+      - name: Build Container Image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./python-package-version
+          file: ./python-package-version/Dockerfile
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE_NAME }}
+          load: true
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha
+
+      - name: Snyk Container Test via CLI
+        # Continue to the GitHub Action even if vulnerabilities are found
+        continue-on-error: true
+        shell: bash
+        run: |
+          snyk container test \
+            --debug \
+            --exclude-base-image-vulns \
+            --file="./python-package-version/Dockerfile" \
+            --format="legacy" \
+            --org="${SNYK_ORG}" \
+            --platform="linux/amd64" \
+            --policy-path="./python-package-version/.snyk" \
+            --severity-threshold="high" \
+            ${{ env.IMAGE_NAME }}
+
+      - name: Run Snyk Container Test via GitHub Action
+        uses: snyk/actions/docker@master
+        with:
+          image: "${{ env.IMAGE_NAME }}"
+          args: |
+            --debug
+            --exclude-base-image-vulns
+            --file="./python-package-version/Dockerfile"
+            --format="legacy"
+            --org="${SNYK_ORG}"
+            --platform="linux/amd64"
+            --policy-path="./python-package-version/.snyk"
+            --severity-threshold="high"

--- a/.github/workflows/python-package-version.yml
+++ b/.github/workflows/python-package-version.yml
@@ -60,6 +60,7 @@ jobs:
         uses: snyk/actions/docker@master
         with:
           image: "${{ env.IMAGE_NAME }}"
+          command: "container test"
           args: |
             --debug
             --exclude-base-image-vulns

--- a/python-package-version/.snyk
+++ b/python-package-version/.snyk
@@ -1,0 +1,13 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-WS-7266574:
+    - '*':
+        reason: >-
+          VS Code usages will be patched will be ingested in Workbench
+          2024.09.0. Usages in JupyterLab are for tests and are unused in
+          Workbench releases.
+        expires: 2024-10-31T00:00:00.000Z
+        created: 2024-08-29T16:55:08.237Z
+patch: {}

--- a/python-package-version/Dockerfile
+++ b/python-package-version/Dockerfile
@@ -1,0 +1,14 @@
+FROM docker.io/rstudio/rstudio-workbench:ubuntu2204-2024.09.0-375.pro3
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG DEFAULT_PYTHON_VERSION="3.11.7"
+ARG PYTHON_VERSIONS="3.11.7,3.10.14,3.9.19,3.8.19"
+ARG SCRIPTS_DIR=/opt/positscripts
+
+COPY dependencies/install_multi_python.sh /tmp/install_multi_python.sh
+COPY dependencies/requirements.txt /tmp/requirements.txt
+RUN rm -f /opt/python/default \
+    && /tmp/install_multi_python.sh \
+    && ln -s /opt/python/default/bin/snow /usr/local/bin/snow \
+    && rm -f /tmp/install_multi_python.sh /tmp/requirements.txt
+

--- a/python-package-version/README.md
+++ b/python-package-version/README.md
@@ -1,0 +1,55 @@
+# Python Package Version with Four Segments
+
+This archive contains an example Dockerfile and associated files to recreate an issue scanning
+
+## Requirements
+
+- [Docker](https://docs.docker.com/engine/install/)
+- [Snyk CLI](https://docs.snyk.io/snyk-cli/install-or-update-the-snyk-cli)
+- [Just](https://just.systems/man/en/chapter_5.html)
+
+## Usage
+
+The image can be built using the following command from within this directory. Alternatively, the `docker buildx build` command could be called manually using similar options to those located in the `justfile`.
+```bash
+just build
+```
+
+The failing Snyk test command can then be triggered using the following command. Alternatively, the `snyk container test` command could be called manually using similar options to those located in the `justfile`.
+```bash
+just snyk-test
+```
+
+Example expected output is in the next section below.
+
+The Dockerfile in this archive references one of Posit's upstream Docker images, [Workbench](https://github.com/rstudio/rstudio-docker-products/blob/dev/workbench/Dockerfile.ubuntu2204), as a base image. Workbench utilizes another couple base images, [product-base-pro](https://github.com/rstudio/rstudio-docker-products/blob/dev/product/pro/Dockerfile.ubuntu2204) and [product-base](https://github.com/rstudio/rstudio-docker-products/blob/dev/product/base/Dockerfile.ubuntu2204). The Dockerfile directly utilizes a script included in product-base, [install_python.sh](https://github.com/rstudio/rstudio-docker-products/blob/dev/product/base/scripts/ubuntu/install_python.sh). These images and files are publicly available and could help aid in further investigation of a root cause.
+
+## Original Error Output
+
+```bash
+$ just build
+docker buildx build -f /home/ianp/Documents/snyk-85535/Dockerfile -t "rstudio/rstudio-workbench-snyk-85535:latest" --load .
+[+] Building 619.5s (10/10) FINISHED                                                                                                                                                                                         docker-container:posit-builder
+ => [internal] load build definition from Dockerfile                                                                                                                                                                                                   0.0s
+ => => transferring dockerfile: 595B                                                                                                                                                                                                                   0.0s
+ => [internal] load metadata for docker.io/rstudio/rstudio-workbench:ubuntu2204-2024.04.2-764.pro1                                                                                                                                                     1.2s
+ => [internal] load .dockerignore                                                                                                                                                                                                                      0.0s
+ => => transferring context: 2B                                                                                                                                                                                                                        0.0s
+ => [1/4] FROM docker.io/rstudio/rstudio-workbench:ubuntu2204-2024.04.2-764.pro1@sha256:38660f9b5083a726af149eba0d2219f629e2132b57387443507fb5383aa780e0                                                                                               0.0s
+ => => resolve docker.io/rstudio/rstudio-workbench:ubuntu2204-2024.04.2-764.pro1@sha256:38660f9b5083a726af149eba0d2219f629e2132b57387443507fb5383aa780e0                                                                                               0.0s
+ => [internal] load build context                                                                                                                                                                                                                      0.0s
+ => => transferring context: 1.56kB                                                                                                                                                                                                                    0.0s
+ => CACHED [2/4] COPY dependencies/install_multi_python.sh /tmp/install_multi_python.sh                                                                                                                                                                0.0s
+ => CACHED [3/4] COPY dependencies/requirements.txt /tmp/requirements.txt                                                                                                                                                                              0.0s
+ => [4/4] RUN rm -f /opt/python/default     && /tmp/install_multi_python.sh     && ln -s /opt/python/default/bin/snow /usr/local/bin/snow     && rm -f /tmp/install_multi_python.sh /tmp/requirements.txt                                            452.9s
+ => exporting to oci image format                                                                                                                                                                                                                    164.7s
+ => => exporting layers                                                                                                                                                                                                                              109.9s
+ => => exporting manifest sha256:1a360b798fc494c0064ecd0e5186f8115eb70cc816fca228b2d6fd6daedecffc                                                                                                                                                      0.0s
+ => => exporting config sha256:5630b128cbc3db0e794aa692ce17da2fb76256bf44eebc1d74c014b92560760e                                                                                                                                                        0.0s
+ => => sending tarball                                                                                                                                                                                                                                54.8s
+ => importing to docker                                                                                                                                                                                                                                0.0s
+$ just snyk-test
+snyk container test --exclude-base-image-vulns --file="/home/ianp/Documents/snyk-85535/Dockerfile" --format="legacy" --org="REDACTED" --platform="linux/amd64" --severity-threshold="high" rstudio/rstudio-workbench-snyk-85535:latest
+Invalid Version: 71.1.0.20240726
+error: Recipe `snyk-test` failed on line 9 with exit code 2
+```

--- a/python-package-version/dependencies/install_multi_python.sh
+++ b/python-package-version/dependencies/install_multi_python.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -exo pipefail
+
+update-alternatives --install /usr/bin/python3 python /usr/bin/python3.10 10
+
+for version in ${PYTHON_VERSIONS//,/ }
+do
+    # Install Python version
+    PYTHON_VERSION=${version} ${SCRIPTS_DIR}/install_python.sh -d -r /tmp/requirements.txt
+
+    # Set as default if applicable
+    if [[ ${version} == ${DEFAULT_PYTHON_VERSION} ]]; then
+      priority=2
+      ln -sf /opt/python/${version} /opt/python/default
+    else
+      priority=1
+    fi
+
+    # Create PATH symlinks for python3.x and pip3.x
+    ln -sf /opt/python/${version}/bin/python3 /usr/local/bin/python${version%\.*}
+    ln -sf /opt/python/${version}/bin/pip3 /usr/local/bin/pip${version%\.*}
+    update-alternatives --install /usr/bin/python3 python /opt/python/${version}/bin/python3 ${priority}
+
+    # Install Jupyter kernel
+    /opt/python/${version}/bin/python3 -m pip install ipykernel
+    /opt/python/${version}/bin/python3 -m ipykernel install --name "py${version%\.*}" --display-name "Python ${version%\.*}"
+done
+
+# Shim default Python installation to /etc/profile.d
+# Reference: https://docs.posit.co/ide/server-pro/python/configuring_default.html
+echo "PATH=/opt/python/default/bin:\$PATH" >> /etc/profile.d/python.sh
+chmod +x /etc/profile.d/python.sh

--- a/python-package-version/dependencies/requirements.txt
+++ b/python-package-version/dependencies/requirements.txt
@@ -1,0 +1,8 @@
+pyodbc
+snowflake
+snowflake-cli-labs
+snowflake-connector-python
+snowflake-ingest
+snowflake-ml-python
+snowflake-snowpark-python
+snowflake-sqlalchemy

--- a/python-package-version/justfile
+++ b/python-package-version/justfile
@@ -1,0 +1,26 @@
+CWD := justfile_directory()
+
+IMAGE_NAME := env("IMAGE_NAME", "rstudio/rstudio-workbench-snyk:latest")
+
+SNYK_ORG := env("SNYK_ORG")
+SNYK_TOKEN := env("SNYK_TOKEN")
+
+build:
+  docker buildx build \
+    -f {{CWD}}/Dockerfile \
+    -t "{{IMAGE_NAME}}" \
+    --load \
+    {{CWD}}
+
+snyk-test:
+  snyk container test \
+    --debug \
+    --exclude-base-image-vulns \
+    --file="{{WORKING_DIR}}/Dockerfile" \
+    --format="legacy" \
+    --org="${SNYK_ORG}" \
+    --platform="linux/amd64" \
+    --policy-path="{{CWD}}" \
+    --severity-threshold="high" \
+    {{IMAGE_NAME}}
+


### PR DESCRIPTION
This reproducible example demonstrates that while the Snyk CLI now works
correctly for Python packages that contain 4 segements in the version,
scanning using the Snyk-provided GitHub Action fails.
